### PR TITLE
Add constant-time length operations on lists

### DIFF
--- a/HCollections.Test/HCollections.Test.fsproj
+++ b/HCollections.Test/HCollections.Test.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="TestHList.fs" />
     <Compile Include="TestTypeList.fs" />
     <Compile Include="TestHUnion.fs" />
     <Compile Include="TestSumOfProducts.fs" />

--- a/HCollections.Test/TestHList.fs
+++ b/HCollections.Test/TestHList.fs
@@ -1,0 +1,38 @@
+﻿namespace HCollections.Test
+
+open HCollections
+open TypeEquality
+open System
+open Xunit
+
+module TestHList =
+
+    [<Fact>]
+    let ``HList to type list is correct for an empty HList`` () =
+        let testHlist = HList.empty
+
+        Assert.Equal (TypeList.empty, HList.toTypeList testHlist)
+
+    [<Fact>]
+    let ``HList to type list is correct for an HList of size 1`` () =
+        let testHlist = HList.empty |> HList.cons 300
+
+        Assert.Equal (TypeList.empty |> TypeList.cons<int, _>, HList.toTypeList testHlist)
+
+    [<Fact>]
+    let ``HList to type list is correct for an HList of size 4`` () =
+        let hlist : (float -> int -> string -> bool -> unit) HList =
+            HList.empty
+            |> HList.cons false
+            |> HList.cons "hi"
+            |> HList.cons 300
+            |> HList.cons 4.0
+
+        let expected =
+            TypeList.empty
+            |> TypeList.cons<bool, _>
+            |> TypeList.cons<string, _>
+            |> TypeList.cons<int, _>
+            |> TypeList.cons<float, _>
+
+        Assert.Equal (expected, HList.toTypeList hlist)

--- a/HCollections.Test/TestHList.fs
+++ b/HCollections.Test/TestHList.fs
@@ -17,7 +17,7 @@ module TestHList =
     let ``HList to type list is correct for an HList of size 1`` () =
         let testHlist = HList.empty |> HList.cons 300
 
-        Assert.Equal (TypeList.empty |> TypeList.cons<int, _>, HList.toTypeList testHlist)
+        Assert.Equal<Type list> (TypeList.empty |> TypeList.cons<int, _> |> TypeList.toTypes, HList.toTypeList testHlist |> TypeList.toTypes)
 
     [<Fact>]
     let ``HList to type list is correct for an HList of size 4`` () =
@@ -35,4 +35,4 @@ module TestHList =
             |> TypeList.cons<int, _>
             |> TypeList.cons<float, _>
 
-        Assert.Equal (expected, HList.toTypeList hlist)
+        Assert.Equal<Type list> (TypeList.toTypes expected, HList.toTypeList hlist |> TypeList.toTypes)

--- a/HCollections.Test/TestHUnion.fs
+++ b/HCollections.Test/TestHUnion.fs
@@ -30,3 +30,29 @@ module TestHUnion =
 
         let actual = testUnion |> HUnion.getSingleton
         Assert.Equal(1234, actual)
+
+    [<Fact>]
+    let ``toTypeList is correct on a union of size 1`` () =
+    
+        let union = testUnion
+        let expected : TypeList<int -> unit> = TypeList.empty |> TypeList.cons
+        Assert.Equal(expected, HUnion.toTypeList union)
+
+    [<Fact>]
+    let ``toTypeList is correct on a bigger union`` () =
+    
+        let union =
+            HUnion.make (TypeList.empty |> TypeList.cons<int, _> |> TypeList.cons<float, _>) ()
+            |> HUnion.extend<string, _>
+            |> HUnion.extend<float, _>
+
+        let expected : TypeList<float -> string -> unit -> float -> int -> unit> =
+            TypeList.empty
+            |> TypeList.cons
+            |> TypeList.cons
+            |> TypeList.cons
+            |> TypeList.cons
+            |> TypeList.cons
+
+        Assert.Equal(expected, HUnion.toTypeList union)
+

--- a/HCollections.Test/TestHUnion.fs
+++ b/HCollections.Test/TestHUnion.fs
@@ -1,5 +1,6 @@
 namespace HCollections.Test
 
+open System
 open HCollections
 open Xunit
 
@@ -35,8 +36,12 @@ module TestHUnion =
     let ``toTypeList is correct on a union of size 1`` () =
     
         let union = testUnion
-        let expected : TypeList<int -> unit> = TypeList.empty |> TypeList.cons
-        Assert.Equal(expected, HUnion.toTypeList union)
+        let expected =
+            TypeList.empty
+            |> TypeList.cons<int, _>
+            |> TypeList.toTypes
+
+        Assert.Equal<Type list>(expected, HUnion.toTypeList union |> TypeList.toTypes)
 
     [<Fact>]
     let ``toTypeList is correct on a bigger union`` () =
@@ -53,6 +58,7 @@ module TestHUnion =
             |> TypeList.cons
             |> TypeList.cons
             |> TypeList.cons
+        let expected = expected |> TypeList.toTypes
 
-        Assert.Equal(expected, HUnion.toTypeList union)
+        Assert.Equal<Type list>(expected, HUnion.toTypeList union |> TypeList.toTypes)
 

--- a/HCollections.Test/TestTypeList.fs
+++ b/HCollections.Test/TestTypeList.fs
@@ -1,6 +1,7 @@
 ﻿namespace HCollections.Test
 
 open HCollections
+open TypeEquality
 open System
 open Xunit
 
@@ -18,3 +19,34 @@ module TestTypeList =
         let expected = [ typeof<int> ; typeof<string> ; typeof<bool> ]
 
         Assert.Equal<Type list>(expected, ts |> TypeList.toTypes)
+
+    [<Fact>]
+    let ``TypeList.length is correct on the empty list`` () =
+        Assert.Equal<int> (0, TypeList.length TypeList.empty)
+
+    [<Fact>]
+    let ``TypeList.length is correct on a list of length 1`` () =
+        let ts : (int -> unit) TypeList =
+            TypeList.empty
+            |> TypeList.cons
+        Assert.Equal<int> (1, TypeList.length ts)
+
+    [<Fact>]
+    let ``TypeList.length is correct on a list of length 3 which was made by splitting a list of length 4`` () =
+        let ts : (float -> int -> string -> bool -> unit) TypeList =
+            TypeList.empty
+            |> TypeList.cons
+            |> TypeList.cons
+            |> TypeList.cons
+            |> TypeList.cons
+        let chopped : (int -> string -> bool -> unit) TypeList =
+            match TypeList.split ts with
+            | Choice1Of2 _ -> failwith "The split should definitely have worked"
+            | Choice2Of2 teq -> 
+                teq.Apply { new TypeListConsEvaluator<_,_> with
+                    member __.Eval<'u, 'us> (us : 'us TypeList) (t : Teq<float -> int -> string -> bool -> unit, 'u -> 'us>) =
+                        us
+                        |> Teq.castFrom (TypeList.cong (Teq.Cong.rangeOf t))
+                }
+
+        Assert.Equal<int> (3, TypeList.length chopped)

--- a/HCollections/HList.fs
+++ b/HCollections/HList.fs
@@ -7,16 +7,16 @@ open TypeEquality
 type 'ts HList =
     private
     | Empty of Teq<'ts, unit>
-    | Cons of 'ts HListConsCrate
+    | Cons of 'ts HListConsCrate * length : int
 
 and private HListConsEvaluator<'ts, 'ret> =
-    abstract member Eval<'t, 'ts2> : 't -> 'ts2 HList -> Teq<'ts, 't -> 'ts2> -> 'ret
+    abstract Eval<'t, 'ts2> : 't -> 'ts2 HList -> Teq<'ts, 't -> 'ts2> -> 'ret
 
 and private 'ts HListConsCrate =
-    abstract member Apply<'ret> : HListConsEvaluator<'ts, 'ret> -> 'ret
+    abstract Apply<'ret> : HListConsEvaluator<'ts, 'ret> -> 'ret
 
 type 'state HListFolder =
-    abstract member Folder<'a> : 'state -> 'a -> 'state
+    abstract Folder<'a> : 'state -> 'a -> 'state
 
 module HList =
 
@@ -25,25 +25,24 @@ module HList =
 
     let empty = HList.Empty Teq.refl
 
-    let cons (x : 't) (xs : 'ts HList) =
-        HList.Cons
-            { new HListConsCrate<_> with
-                member __.Apply e = e.Eval x xs Teq.refl
-            }
-
     let rec length<'ts> (xs : 'ts HList) : int =
         match xs with
         | Empty _ -> 0
-        | Cons b ->
-            b.Apply
-                { new HListConsEvaluator<_,_> with
-                    member __.Eval _ xs _ = length xs + 1
-                }
+        | Cons (b, length) -> length
+
+    let cons (x : 't) (xs : 'ts HList) =
+        let crate = 
+            { new HListConsCrate<_> with
+                member __.Apply e = e.Eval x xs Teq.refl
+            }
+        let length = 1 + length xs
+
+        HList.Cons (crate, length)
 
     let head (xs : ('t -> 'ts) HList) : 't =
         match xs with
         | Empty _ -> raise Unreachable
-        | Cons b ->
+        | Cons (b, _length) ->
             b.Apply
                 { new HListConsEvaluator<_,_> with
                     member __.Eval x _ teq =
@@ -54,7 +53,7 @@ module HList =
     let tail (xs : ('t -> 'ts) HList) : 'ts HList =
         match xs with
         | Empty _ -> raise Unreachable
-        | Cons b ->
+        | Cons (b, _length) ->
             b.Apply
                 { new HListConsEvaluator<_,_> with
                     member __.Eval _ xs teq =
@@ -65,7 +64,7 @@ module HList =
     let rec fold<'state, 'ts> (folder : 'state HListFolder) (seed : 'state) (xs : 'ts HList) : 'state =
         match xs with
         | Empty _ -> seed
-        | Cons c ->
+        | Cons (c, _length) ->
             c.Apply
                 { new HListConsEvaluator<_,_> with
                     member __.Eval x xs teq = fold folder (folder.Folder seed x) xs
@@ -75,7 +74,7 @@ module HList =
         match xs with
         | Empty teq ->
             TypeList.empty |> Teq.castFrom (teq |> TypeList.cong)
-        | Cons b ->
+        | Cons (b, _length) ->
             b.Apply
                 { new HListConsEvaluator<_,_> with
                     member __.Eval (_ : 'a) xs teq =

--- a/HCollections/HList.fs
+++ b/HCollections/HList.fs
@@ -20,7 +20,7 @@ type 'state HListFolder =
 
 module HList =
 
-    let rec toTypeList<'ts> (xs : 'ts HList) : 'ts TypeList =
+    let toTypeList<'ts> (xs : 'ts HList) : 'ts TypeList =
         match xs with
         | Empty teq ->
             TypeList.empty |> Teq.castFrom (teq |> TypeList.cong)
@@ -31,7 +31,7 @@ module HList =
 
     let empty = HList.Empty Teq.refl
 
-    let rec length<'ts> (xs : 'ts HList) : int =
+    let length<'ts> (xs : 'ts HList) : int =
         match xs with
         | Empty _ -> 0
         | Cons (_b, tl) -> TypeList.length tl

--- a/HCollections/HList.fsi
+++ b/HCollections/HList.fsi
@@ -22,7 +22,7 @@ type 'state HListFolder =
     /// F takes the current state, the next element in the HList and returns a new state.
     /// Because elements in the HList may have arbitrary type, F must be generic on
     /// the element type, i.e. can be called for any element type.
-    abstract member Folder<'a> : 'state -> 'a -> 'state
+    abstract Folder<'a> : 'state -> 'a -> 'state
 
 module HList =
 
@@ -53,4 +53,5 @@ module HList =
 
     /// Given an HList, returns a TypeList whose types correspond to the values
     /// of the elements of the HList.
+    /// This operation takes time constant in the length of the HList.
     val toTypeList<'ts> : 'ts HList -> 'ts TypeList

--- a/HCollections/HList.fsi
+++ b/HCollections/HList.fsi
@@ -36,7 +36,8 @@ module HList =
     /// Given an element and an HList, returns a new HList with the element prepended to it.
     val cons<'t, 'ts> : 't -> 'ts HList -> ('t -> 'ts) HList
 
-    /// Returns the length of the given HList
+    /// Returns the length of the given HList.
+    /// This operation takes time constant in the length of the HList.
     val length<'ts> : 'ts HList -> int
 
     /// Given a non-empty HList, returns the first element.

--- a/HCollections/HListT.fs
+++ b/HCollections/HListT.fs
@@ -25,7 +25,7 @@ module HListT =
 
     let empty<'elem> : HListT<unit, 'elem> = HListT.Empty Teq.refl
 
-    let rec length<'ts, 'elem> (xs : HListT<'ts, 'elem>) : int =
+    let length<'ts, 'elem> (xs : HListT<'ts, 'elem>) : int =
         match xs with
         | Empty _ -> 0
         | Cons (_, length) -> length

--- a/HCollections/HListT.fsi
+++ b/HCollections/HListT.fsi
@@ -44,7 +44,8 @@ module HListT =
     /// returns a new HListT with the elements prepended to it.
     val cons<'t, 'ts, 'elem> : 't -> 'elem -> HListT<'ts, 'elem> -> HListT<'t -> 'ts, 'elem>
 
-    /// Returns the length of the given HListT
+    /// Returns the length of the given HListT.
+    /// This operation takes time constant in the length of the HListT.
     val length<'ts, 'elem> : HListT<'ts, 'elem> -> int
 
     /// Given a non-empty HListT, returns the first pair of elements.

--- a/HCollections/HUnion.fs
+++ b/HCollections/HUnion.fs
@@ -34,7 +34,7 @@ module HUnion =
         }
         |> Value
 
-    let rec toTypeList<'ts> (union : 'ts HUnion) : 'ts TypeList =
+    let toTypeList<'ts> (union : 'ts HUnion) : 'ts TypeList =
         match union with
         | Value c ->
             c.Apply

--- a/HCollections/HUnion.fsi
+++ b/HCollections/HUnion.fsi
@@ -44,4 +44,5 @@ module HUnion =
 
     /// Given an HUnion, returns a TypeList whose types correspond to the
     /// cases of the HUnion.
+    /// This operation takes time constant in the size of the HUnion.
     val toTypeList : 'ts HUnion -> 'ts TypeList

--- a/HCollections/TypeList.fs
+++ b/HCollections/TypeList.fs
@@ -8,13 +8,13 @@ open TypeEquality
 type 'ts TypeList =
     private
     | Empty of Teq<'ts, unit>
-    | Cons of 'ts TypeListConsCrate
+    | Cons of 'ts TypeListConsCrate * length : int
 
 and TypeListConsEvaluator<'ts, 'ret> =
-    abstract member Eval<'t, 'ts2> : 'ts2 TypeList -> Teq<'ts, 't -> 'ts2> -> 'ret
+    abstract Eval<'t, 'ts2> : 'ts2 TypeList -> Teq<'ts, 't -> 'ts2> -> 'ret
 
 and 'ts TypeListConsCrate =
-    abstract member Apply<'ret> : TypeListConsEvaluator<'ts, 'ret> -> 'ret
+    abstract Apply<'ret> : TypeListConsEvaluator<'ts, 'ret> -> 'ret
 
 [<RequireQualifiedAccess>]
 module TypeList =
@@ -24,16 +24,25 @@ module TypeList =
 
     let empty = Empty Teq.refl
 
+    let length<'ts> (ts : 'ts TypeList) : int =
+        match ts with
+        | Empty _ -> 0
+        | Cons (_crate, length) ->
+            length
+
     let cons<'t, 'ts> (types : 'ts TypeList) =
-        { new TypeListConsCrate<_> with
-            member __.Apply e = e.Eval types Teq.refl<'t -> 'ts>
-        }
-        |> Cons
+        let crate =
+            { new TypeListConsCrate<_> with
+                member __.Apply e = e.Eval types Teq.refl<'t -> 'ts>
+            }
+        let length = 1 + length types
+
+        Cons (crate, length)
 
     let tail<'t, 'ts> (ts : ('t -> 'ts) TypeList) : 'ts TypeList =
         match ts with
         | Empty _ -> raise Unreachable
-        | Cons crate ->
+        | Cons (crate, _length) ->
             crate.Apply
                 { new TypeListConsEvaluator<_,_> with
                     member __.Eval ts teq =
@@ -43,14 +52,15 @@ module TypeList =
     let split (ts : 'ts TypeList) =
         match ts with
         | Empty teq -> Choice1Of2 teq
-        | Cons crate -> Choice2Of2 crate
+        | Cons (crate, _length) -> Choice2Of2 crate
 
     let rec toTypes<'ts> (ts : 'ts TypeList) : Type list =
         match ts with
         | Empty _ -> []
-        | Cons crate ->
+        | Cons (crate, _length) ->
             crate.Apply
                 { new TypeListConsEvaluator<_,_> with
                     member __.Eval ts (_ : Teq<_,'a -> _>) =
                         typeof<'a> :: toTypes ts
                 }
+

--- a/HCollections/TypeList.fsi
+++ b/HCollections/TypeList.fsi
@@ -15,10 +15,10 @@ open TypeEquality
 type 'ts TypeList
 
 type TypeListConsEvaluator<'ts, 'ret> =
-    abstract member Eval<'t, 'ts2> : 'ts2 TypeList -> Teq<'ts, 't -> 'ts2> -> 'ret
+    abstract Eval<'t, 'ts2> : 'ts2 TypeList -> Teq<'ts, 't -> 'ts2> -> 'ret
 
 and 'ts TypeListConsCrate =
-    abstract member Apply<'ret> : TypeListConsEvaluator<'ts, 'ret> -> 'ret
+    abstract Apply<'ret> : TypeListConsEvaluator<'ts, 'ret> -> 'ret
 
 
 [<RequireQualifiedAccess>]
@@ -45,3 +45,8 @@ module TypeList =
 
     /// Given a TypeList, returns the corresponding list of runtime types.
     val toTypes : 'ts TypeList -> Type list
+
+    /// Given a TypeList, returns the length of the list.
+    /// This is equal to the number of `cons` operations on `empty` that would create the list.
+    /// This operation takes time constant in the length of the TypeList.
+    val length : 'ts TypeList -> int


### PR DESCRIPTION
I ended up wanting them quite a bit in practice for error messages, when I was descending into records and tuples.