### PR TITLE
Adding HList.split and HListT.split

### DIFF
--- a/HCollections.Test/TestHList.fs
+++ b/HCollections.Test/TestHList.fs
@@ -59,7 +59,7 @@ module TestHList =
         | Choice2Of2 c ->
             c.Apply
                 { new HListConsEvaluator<string -> unit,int> with
-                    member __.Eval (t,head,tail) =
+                    member __.Eval (head,tail,t) =
                         let head = Teq.castFrom (Teq.Cong.domainOf t) head
                         let tail = Teq.castFrom (HList.cong (Teq.Cong.rangeOf t)) tail
                         Assert.Equal<_> (emptyHList, tail)

--- a/HCollections.Test/TestHList.fs
+++ b/HCollections.Test/TestHList.fs
@@ -57,12 +57,13 @@ module TestHList =
         match result with
         | Choice1Of2 _ -> failwith "The HListT is empty."
         | Choice2Of2 c ->
-            c.Apply
-                { new HListConsEvaluator<string -> unit,int> with
-                    member __.Eval (head,tail,t) =
-                        let head = Teq.castFrom (Teq.Cong.domainOf t) head
-                        let tail = Teq.castFrom (HList.cong (Teq.Cong.rangeOf t)) tail
-                        Assert.Equal<_> (emptyHList, tail)
-                        Assert.Equal (head, "hi")
-                        5
-                } |> ignore
+            let head,tail =
+                c.Apply
+                    { new HListConsEvaluator<string -> unit, string * unit HList> with
+                        member __.Eval (head,tail,t) =
+                            let head = Teq.castFrom (Teq.Cong.domainOf t) head
+                            let tail = Teq.castFrom (HList.cong (Teq.Cong.rangeOf t)) tail
+                            head,tail
+                    }
+            Assert.Equal<_> (tail, emptyHList)
+            Assert.Equal (head, "hi")

--- a/HCollections.Test/TestHList.fs
+++ b/HCollections.Test/TestHList.fs
@@ -36,3 +36,33 @@ module TestHList =
             |> TypeList.cons<float, _>
 
         Assert.Equal<Type list> (TypeList.toTypes expected, HList.toTypeList hlist |> TypeList.toTypes)
+
+    [<Fact>]
+    let ``HList.split on an empty HList returns the proof that it's an empty HList`` () =
+        let testHList =
+            HList.empty
+        let result = HList.split testHList
+        match result with
+        | Choice1Of2 t -> Teq.castFrom t ()
+        | Choice2Of2 _ -> failwith "The HList is not empty."
+
+    [<Fact>]
+    let ``HList.split on a non-empty HList returns the elements at the head of the HList and the tail`` () =
+        let emptyHList =
+            HList.empty
+        let testHList =
+            emptyHList
+            |> HList.cons "hi"
+        let result = HList.split testHList
+        match result with
+        | Choice1Of2 _ -> failwith "The HListT is empty."
+        | Choice2Of2 c ->
+            c.Apply
+                { new HListConsEvaluator<string -> unit,int> with
+                    member __.Eval (t,head,tail) =
+                        let head = Teq.castFrom (Teq.Cong.domainOf t) head
+                        let tail = Teq.castFrom (HList.cong (Teq.Cong.rangeOf t)) tail
+                        Assert.Equal<_> (emptyHList, tail)
+                        Assert.Equal (head, "hi")
+                        5
+                } |> ignore

--- a/HCollections.Test/TestHListT.fs
+++ b/HCollections.Test/TestHListT.fs
@@ -3,7 +3,6 @@
 open HCollections
 open System
 open TypeEquality
-open TypeEquality
 open Xunit
 
 module TestHListT =

--- a/HCollections.Test/TestHListT.fs
+++ b/HCollections.Test/TestHListT.fs
@@ -97,7 +97,7 @@ module TestHListT =
         | Choice2Of2 c ->
             c.Apply
                 { new HListTConsEvaluator<string -> unit,int,int> with
-                    member __.Eval (t,head,elem,tail) =
+                    member __.Eval (head,elem,tail,t) =
                         let head = Teq.castFrom (Teq.Cong.domainOf t) head
                         let tail = Teq.castFrom (HListT.cong (Teq.Cong.rangeOf t) Teq.refl) tail
                         Assert.Equal<_> (emptyHListT, tail)

--- a/HCollections.Test/TestHListT.fs
+++ b/HCollections.Test/TestHListT.fs
@@ -95,13 +95,14 @@ module TestHListT =
         match result with
         | Choice1Of2 _ -> failwith "The HListT is empty."
         | Choice2Of2 c ->
-            c.Apply
-                { new HListTConsEvaluator<string -> unit,int,int> with
-                    member __.Eval (head,elem,tail,t) =
-                        let head = Teq.castFrom (Teq.Cong.domainOf t) head
-                        let tail = Teq.castFrom (HListT.cong (Teq.Cong.rangeOf t) Teq.refl) tail
-                        Assert.Equal<_> (emptyHListT, tail)
-                        Assert.Equal (elem, 4)
-                        Assert.Equal (head, "hi")
-                        5
-                } |> ignore
+            let head, elem, tail =
+                c.Apply
+                    { new HListTConsEvaluator<string -> unit,int,string * int * HListT<unit, int>> with
+                        member __.Eval (head,elem,tail,t) =
+                            let head = Teq.castFrom (Teq.Cong.domainOf t) head
+                            let tail = Teq.castFrom (HListT.cong (Teq.Cong.rangeOf t) Teq.refl) tail
+                            head, elem, tail
+                    }
+            Assert.Equal<_> (tail, emptyHListT)
+            Assert.Equal (elem, 4)
+            Assert.Equal (head, "hi")

--- a/HCollections/HList.fs
+++ b/HCollections/HList.fs
@@ -9,12 +9,11 @@ type 'ts HList =
     | Empty of Teq<'ts, unit>
     | Cons of 'ts HListCons * 'ts TypeList
 
-and HListConsEvaluator<'ts, 'ret> =
-    abstract Eval<'t, 'ts2> : 't * 'ts2 HList * Teq<'ts, 't -> 'ts2> -> 'ret
-
 and 'ts HListCons =
     abstract Apply<'ret> : HListConsEvaluator<'ts, 'ret> -> 'ret
 
+and HListConsEvaluator<'ts, 'ret> =
+    abstract Eval<'t, 'ts2> : 't * 'ts2 HList * Teq<'ts, 't -> 'ts2> -> 'ret
 
 type 'state HListFolder =
     abstract Folder<'a> : 'state -> 'a -> 'state

--- a/HCollections/HList.fs
+++ b/HCollections/HList.fs
@@ -9,17 +9,12 @@ type 'ts HList =
     | Empty of Teq<'ts, unit>
     | Cons of 'ts HListConsCrate * 'ts TypeList
 
-and private HListConsEval<'ts, 'ret> =
-    abstract Eval<'t, 'ts2> : 't -> 'ts2 HList -> Teq<'ts, 't -> 'ts2> -> 'ret
+and HListConsEvaluator<'ts, 'ret> =
+    abstract Eval<'t, 'ts2> : 't * 'ts2 HList * Teq<'ts, 't -> 'ts2> -> 'ret
 
-and private 'ts HListConsCrate =
-    abstract Apply<'ret> : HListConsEval<'ts, 'ret> -> 'ret
+and 'ts HListConsCrate =
+    abstract Apply<'ret> : HListConsEvaluator<'ts, 'ret> -> 'ret
 
-type 'ts HListCons =
-    abstract Apply<'r> : HListConsEvaluator<'ts, 'r> -> 'r
-
-and HListConsEvaluator<'ts, 'r> =
-    abstract Eval<'t, 'u> : Teq<'ts, 't -> 'u> * 't * 'u HList -> 'r
 
 type 'state HListFolder =
     abstract Folder<'a> : 'state -> 'a -> 'state
@@ -45,7 +40,7 @@ module HList =
     let cons (x : 't) (xs : 'ts HList) =
         let crate = 
             { new HListConsCrate<_> with
-                member __.Apply e = e.Eval x xs Teq.refl
+                member __.Apply e = e.Eval (x, xs, Teq.refl)
             }
         let tl = TypeList.cons<'t, 'ts> (toTypeList xs)
 
@@ -56,8 +51,8 @@ module HList =
         | Empty _ -> raise Unreachable
         | Cons (b, _length) ->
             b.Apply
-                { new HListConsEval<_,_> with
-                    member __.Eval x _ teq =
+                { new HListConsEvaluator<_,_> with
+                    member __.Eval (x, _, teq) =
                         let teq = teq |> Teq.Cong.domainOf
                         x |> Teq.castFrom teq
                 }
@@ -67,8 +62,8 @@ module HList =
         | Empty _ -> raise Unreachable
         | Cons (b, _length) ->
             b.Apply
-                { new HListConsEval<_,_> with
-                    member __.Eval _ xs teq =
+                { new HListConsEvaluator<_,_> with
+                    member __.Eval (_, xs, teq) =
                         let teq = teq |> Teq.Cong.rangeOf |> cong
                         xs |> Teq.castFrom teq
                 }
@@ -78,17 +73,17 @@ module HList =
         | Empty _ -> seed
         | Cons (c, _length) ->
             c.Apply
-                { new HListConsEval<_,_> with
-                    member __.Eval x xs teq = fold folder (folder.Folder seed x) xs
+                { new HListConsEvaluator<_,_> with
+                    member __.Eval (x, xs, teq) = fold folder (folder.Folder seed x) xs
                 }
 
-    let split (v : 'ts HList) : Choice<Teq<'ts, unit>, 'ts HListCons> =
+    let split (v : 'ts HList) : Choice<Teq<'ts, unit>, 'ts HListConsCrate> =
         match v with
         | Empty ts -> Choice<_,_>.Choice1Of2 ts
         | Cons (c,_) ->
             c.Apply
-                { new HListConsEval<_,_> with
-                    member __.Eval<'t, 'u> head tail (ts : Teq<'ts, 't -> 'u>) =
-                        { new HListCons<_> with member __.Apply e = e.Eval (ts, head, tail) }
+                { new HListConsEvaluator<_,_> with
+                    member __.Eval<'t, 'u> (head, tail, (ts : Teq<'ts, 't -> 'u>)) =
+                        { new HListConsCrate<_> with member __.Apply e = e.Eval (head, tail, ts) }
                         |> Choice<_,_>.Choice2Of2
                 }

--- a/HCollections/HList.fsi
+++ b/HCollections/HList.fsi
@@ -20,7 +20,7 @@ type 'ts HList
 type HListConsEvaluator<'ts, 'ret> =
     abstract Eval<'t, 'ts2> : 't * 'ts2 HList * Teq<'ts, 't -> 'ts2> -> 'ret
 
-type 'ts HListConsCrate =
+type 'ts HListCons =
     abstract Apply<'ret> : HListConsEvaluator<'ts, 'ret> -> 'ret
 
 /// HListFolder allows you to perform a fold over an HList.
@@ -67,4 +67,4 @@ module HList =
 
     /// Given an HList, returns either a proof that the list is empty, or a crate
     /// containing the head and the tail of the HList.
-    val split : 'ts HList -> Choice<Teq<'ts, unit>, 'ts HListConsCrate>
+    val split : 'ts HList -> Choice<Teq<'ts, unit>, 'ts HListCons>

--- a/HCollections/HList.fsi
+++ b/HCollections/HList.fsi
@@ -14,6 +14,9 @@ open TypeEquality
 [<NoEquality>]
 type 'ts HList
 
+/// Contains the head and the tail of the HList.
+/// The arguments of this crate a tupled due to an issue where recursing through crates with 3 or more
+/// un-tupled arguments will result in non-tail recursive calls.
 type HListConsEvaluator<'ts, 'ret> =
     abstract Eval<'t, 'ts2> : 't * 'ts2 HList * Teq<'ts, 't -> 'ts2> -> 'ret
 

--- a/HCollections/HList.fsi
+++ b/HCollections/HList.fsi
@@ -14,11 +14,11 @@ open TypeEquality
 [<NoEquality>]
 type 'ts HList
 
-type 'ts HListCons =
-    abstract Apply<'r> : HListConsEvaluator<'ts, 'r> -> 'r
+type HListConsEvaluator<'ts, 'ret> =
+    abstract Eval<'t, 'ts2> : 't * 'ts2 HList * Teq<'ts, 't -> 'ts2> -> 'ret
 
-and HListConsEvaluator<'ts, 'r> =
-    abstract Eval<'t, 'u> : Teq<'ts, 't -> 'u> * 't * 'u HList -> 'r
+type 'ts HListConsCrate =
+    abstract Apply<'ret> : HListConsEvaluator<'ts, 'ret> -> 'ret
 
 /// HListFolder allows you to perform a fold over an HList.
 /// The single type parameter, 'state, denotes the type of the value
@@ -64,4 +64,4 @@ module HList =
 
     /// Given an HList, returns either a proof that the list is empty, or a crate
     /// containing the head and the tail of the HList.
-    val split : 'ts HList -> Choice<Teq<'ts, unit>, 'ts HListCons>
+    val split : 'ts HList -> Choice<Teq<'ts, unit>, 'ts HListConsCrate>

--- a/HCollections/HList.fsi
+++ b/HCollections/HList.fsi
@@ -14,6 +14,12 @@ open TypeEquality
 [<NoEquality>]
 type 'ts HList
 
+type 'ts HListCons =
+    abstract Apply<'r> : HListConsEvaluator<'ts, 'r> -> 'r
+
+and HListConsEvaluator<'ts, 'r> =
+    abstract Eval<'t, 'u> : Teq<'ts, 't -> 'u> * 't * 'u HList -> 'r
+
 /// HListFolder allows you to perform a fold over an HList.
 /// The single type parameter, 'state, denotes the type of the value
 /// that you want the fold to return.
@@ -55,3 +61,7 @@ module HList =
     /// of the elements of the HList.
     /// This operation takes time constant in the length of the HList.
     val toTypeList<'ts> : 'ts HList -> 'ts TypeList
+
+    /// Given an HList, returns either a proof that the list is empty, or a crate
+    /// containing the head and the tail of the HList.
+    val split : 'ts HList -> Choice<Teq<'ts, unit>, 'ts HListCons>

--- a/HCollections/HList.fsi
+++ b/HCollections/HList.fsi
@@ -14,14 +14,14 @@ open TypeEquality
 [<NoEquality>]
 type 'ts HList
 
+type 'ts HListCons =
+    abstract Apply<'ret> : HListConsEvaluator<'ts, 'ret> -> 'ret
+
 /// Contains the head and the tail of the HList.
 /// The arguments of this crate a tupled due to an issue where recursing through crates with 3 or more
 /// un-tupled arguments will result in non-tail recursive calls.
-type HListConsEvaluator<'ts, 'ret> =
+and HListConsEvaluator<'ts, 'ret> =
     abstract Eval<'t, 'ts2> : 't * 'ts2 HList * Teq<'ts, 't -> 'ts2> -> 'ret
-
-type 'ts HListCons =
-    abstract Apply<'ret> : HListConsEvaluator<'ts, 'ret> -> 'ret
 
 /// HListFolder allows you to perform a fold over an HList.
 /// The single type parameter, 'state, denotes the type of the value

--- a/HCollections/HListT.fs
+++ b/HCollections/HListT.fs
@@ -19,7 +19,7 @@ type HListTCons<'ts, 'elem> =
     abstract Apply<'r> : HListTConsEvaluator<'ts, 'elem, 'r> -> 'r
 
 and HListTConsEvaluator<'ts, 'elem, 'r> =
-    abstract Eval<'t, 'u> : Teq<'ts, 't -> 'u> * 't * 'elem * HListT<'u, 'elem> -> 'r
+    abstract Eval<'t, 'u> : 't * 'elem * HListT<'u, 'elem> * Teq<'ts, 't -> 'u> -> 'r
 
 type HListTFolder<'state, 'elem> =
     abstract member Folder<'a> : 'state -> 'a -> 'elem -> 'state
@@ -98,6 +98,6 @@ module HListT =
                         let hlist = Teq.castTo (HList.cong t) hlist
                         let hlistHead = HList.head hlist
                         let elemHead = List.head elems
-                        { new HListTCons<_,_> with member __.Apply e = e.Eval (t, hlistHead, elemHead, tail) }
+                        { new HListTCons<_,_> with member __.Apply e = e.Eval (hlistHead, elemHead, tail, t) }
                         |> Choice<_,_>.Choice2Of2
                 }

--- a/HCollections/HListT.fs
+++ b/HCollections/HListT.fs
@@ -9,11 +9,17 @@ type HListT<'ts, 'elem> =
     | Empty of 'ts HList * Teq<'ts, unit>
     | Cons of 'ts HList * 'elem list * HListTConsCrate<'ts, 'elem>
 
-and private HListTConsEvaluator<'ts, 'elem, 'ret> =
+and private HListTConsEval<'ts, 'elem, 'ret> =
     abstract member Eval<'t, 'ts2> : HListT<'ts2, 'elem> -> Teq<'ts, 't -> 'ts2> -> 'ret
 
 and private HListTConsCrate<'ts, 'elem> =
-    abstract member Apply<'ret> : HListTConsEvaluator<'ts, 'elem, 'ret> -> 'ret
+    abstract member Apply<'ret> : HListTConsEval<'ts, 'elem, 'ret> -> 'ret
+
+type HListTCons<'ts, 'elem> =
+    abstract Apply<'r> : HListTConsEvaluator<'ts, 'elem, 'r> -> 'r
+
+and HListTConsEvaluator<'ts, 'elem, 'r> =
+    abstract Eval<'t, 'u> : Teq<'ts, 't -> 'u> * 't * 'elem * HListT<'u, 'elem> -> 'r
 
 type HListTFolder<'state, 'elem> =
     abstract member Folder<'a> : 'state -> 'a -> 'elem -> 'state
@@ -64,7 +70,7 @@ module HListT =
         | Empty _ -> raise Unreachable
         | Cons (_, _, cons) ->
             cons.Apply
-                { new HListTConsEvaluator<_,_,_> with
+                { new HListTConsEval<_,_,_> with
                     member __.Eval xs teq =
                         let teq = cong (teq |> Teq.Cong.rangeOf) Teq.refl
                         xs |> Teq.castFrom teq
@@ -75,9 +81,23 @@ module HListT =
         | Empty _ -> seed
         | Cons (hlist, elems, cons) ->
             cons.Apply
-                { new HListTConsEvaluator<_,_,_> with
+                { new HListTConsEval<_,_,_> with
                     member __.Eval xs teq =
                         let x = HList.head (hlist |> Teq.castTo (HList.cong teq))
                         let y = List.head elems
                         fold folder (folder.Folder seed x y) xs
+                }
+
+    let split (v : HListT<'ts, 'elem>) : Choice<Teq<'ts, unit>, HListTCons<'ts, 'elem>> =
+        match v with
+        | Empty (_, t) -> Choice<_,_>.Choice1Of2 t
+        | Cons (hlist, elems, next) ->
+            next.Apply
+                { new HListTConsEval<_,_,_> with
+                    member __.Eval tail t =
+                        let hlist = Teq.castTo (HList.cong t) hlist
+                        let hlistHead = HList.head hlist
+                        let elemHead = List.head elems
+                        { new HListTCons<_,_> with member __.Apply e = e.Eval (t, hlistHead, elemHead, tail) }
+                        |> Choice<_,_>.Choice2Of2
                 }

--- a/HCollections/HListT.fsi
+++ b/HCollections/HListT.fsi
@@ -20,6 +20,9 @@ type HListT<'ts, 'elem>
 type HListTCons<'ts, 'elem> =
     abstract Apply<'r> : HListTConsEvaluator<'ts, 'elem, 'r> -> 'r
 
+/// Contains the head (both heterogenous and homogenous elements) and the tail of the HListT.
+/// The arguments of this crate a tupled due to an issue where recursing through crates with 3 or more
+/// un-tupled arguments will result in non-tail recursive calls.
 and HListTConsEvaluator<'ts, 'elem, 'r> =
     abstract Eval<'t, 'u> : 't * 'elem * HListT<'u, 'elem> * Teq<'ts, 't -> 'u> -> 'r
 

--- a/HCollections/HListT.fsi
+++ b/HCollections/HListT.fsi
@@ -21,7 +21,7 @@ type HListTCons<'ts, 'elem> =
     abstract Apply<'r> : HListTConsEvaluator<'ts, 'elem, 'r> -> 'r
 
 and HListTConsEvaluator<'ts, 'elem, 'r> =
-    abstract Eval<'t, 'u> : Teq<'ts, 't -> 'u> * 't * 'elem * HListT<'u, 'elem> -> 'r
+    abstract Eval<'t, 'u> : 't * 'elem * HListT<'u, 'elem> * Teq<'ts, 't -> 'u> -> 'r
 
 /// HListFolder allows you to perform a fold over an HListT.
 /// The first type parameter, 'state, denotes the type of the value

--- a/HCollections/HListT.fsi
+++ b/HCollections/HListT.fsi
@@ -75,5 +75,5 @@ module HListT =
     val toList<'ts, 'elem> : HListT<'ts, 'elem> -> 'elem list
 
     /// Given an HListT, returns either a proof that the list is empty, or a crate
-    /// containing the head and the tail of the HListT.
+    /// containing the head elements (both the heterogenous and homogenous) and the tail of the HListT.
     val split : HListT<'ts, 'elem> -> Choice<Teq<'ts, unit>, HListTCons<'ts, 'elem>>

--- a/HCollections/HListT.fsi
+++ b/HCollections/HListT.fsi
@@ -17,6 +17,12 @@ open TypeEquality
 [<NoEquality>]
 type HListT<'ts, 'elem>
 
+type HListTCons<'ts, 'elem> =
+    abstract Apply<'r> : HListTConsEvaluator<'ts, 'elem, 'r> -> 'r
+
+and HListTConsEvaluator<'ts, 'elem, 'r> =
+    abstract Eval<'t, 'u> : Teq<'ts, 't -> 'u> * 't * 'elem * HListT<'u, 'elem> -> 'r
+
 /// HListFolder allows you to perform a fold over an HListT.
 /// The first type parameter, 'state, denotes the type of the value
 /// that you want the fold to return.
@@ -67,3 +73,7 @@ module HListT =
 
     /// Given an HListT, returns the corresponding list of homogenous types
     val toList<'ts, 'elem> : HListT<'ts, 'elem> -> 'elem list
+
+    /// Given an HListT, returns either a proof that the list is empty, or a crate
+    /// containing the head and the tail of the HListT.
+    val split : HListT<'ts, 'elem> -> Choice<Teq<'ts, unit>, HListTCons<'ts, 'elem>>


### PR DESCRIPTION
Needed these for something. Whilst it can be achieved using the TypeList.split and then doing it manually I thought it might be nice to add them to the API to reduce the amount of clutter you need to write yourself.

I've opted to make another crate for the Cons case, as opposed to using the crate that is already part of the implementation. For HListT this makes sense, as we want the crate to hold different things. For the HList I decided to create a separate crate to keep the implementation separate from the function, meaning a change to how we store HLists won't involve a major version number change.

Names are probably awful, better suggestions are welcome! I've also added some basic tests but happy to add more if you think there is a case missing